### PR TITLE
Issue #137 - ctools update

### DIFF
--- a/ding_news.make
+++ b/ding_news.make
@@ -21,7 +21,7 @@ projects[cache_actions][subdir] = "contrib"
 projects[cache_actions][version] = "2.0-alpha5"
 
 projects[ctools][subdir] = "contrib"
-projects[ctools][version] = "1.4"
+projects[ctools][version] = "1.5"
 
 projects[cs_adaptive_image][subdir] = "contrib"
 projects[cs_adaptive_image][version] = "1.0"


### PR DESCRIPTION
Updated ctools which fixes PHP 5.3 warnings.