### PR TITLE
Fix using Organic groups for Views relationships

### DIFF
--- a/ding_news.make
+++ b/ding_news.make
@@ -50,6 +50,9 @@ projects[file_entity][version] = "2.0-alpha3"
 projects[og][subdir] = "contrib"
 projects[og][version] = "2.5"
 projects[og][patch][] = "https://www.drupal.org/files/issues/entityreference_fields_do_not_validate-2249261-10.patch"
+; Fix using organic groups for relationships in views
+; https://www.drupal.org/node/1890370
+projects[og][patch][] = "https://www.drupal.org/files/issues/add-gid-to-relationship-field-1890370-34.patch"
 
 projects[similarterms][subdir] = "contrib"
 projects[similarterms][version] = "2.3"


### PR DESCRIPTION
This patch fixes organic groups to support using using them for Views relationships. Without this you get a nasty SQL error.

d.o issue: https://www.drupal.org/node/1890370