### PR TITLE
Issue 1106: Add a custom read more link to groups news list.

### DIFF
--- a/ding_news.module
+++ b/ding_news.module
@@ -94,3 +94,30 @@ function ding_news_install_menu_position($op = 'install') {
     menu_position_delete_rule($exists);
   }
 }
+
+/**
+ * Implements hook_preprocess_views_view().
+ */
+function ding_news_preprocess_views_view(&$vars) {
+  $view = $vars['view'];
+  // Add a custom view more link for the news list for a group.
+  // The standard read more link points to standard news list and it does not
+  // seem to be possible to provide a custom url in another way.
+  // Adding a link in a footer text field means that the text will not be
+  // translatable and the url will not be processed using path alias.
+  if ($view->name = 'ding_news' &&
+    $view->current_display == 'ding_news_groups_list'
+  ) {
+    if (!empty($view->result[0]->og_membership_node_gid)) {
+      $vars['more'] = theme(
+        'views_more',
+        array(
+          'more_url' => url(
+            'temaer/' . $view->result[0]->og_membership_node_gid . '/nyheder'
+          ),
+          'link_text' => t('See all news'),
+        )
+      );
+    }
+  }
+}

--- a/ding_news.views_default.inc
+++ b/ding_news.views_default.inc
@@ -1531,6 +1531,15 @@ function ding_news_views_default_views() {
   $handler->display->display_options['fields']['view_node_1']['element_class'] = 'news-arrow-link';
   $handler->display->display_options['fields']['view_node_1']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['view_node_1']['element_default_classes'] = FALSE;
+  /* Field: OG membership: Group ID */
+  $handler->display->display_options['fields']['gid']['id'] = 'gid';
+  $handler->display->display_options['fields']['gid']['table'] = 'og_membership';
+  $handler->display->display_options['fields']['gid']['field'] = 'gid';
+  $handler->display->display_options['fields']['gid']['relationship'] = 'og_membership_rel';
+  $handler->display->display_options['fields']['gid']['label'] = '';
+  $handler->display->display_options['fields']['gid']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['gid']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['gid']['separator'] = '';
   $handler->display->display_options['defaults']['arguments'] = FALSE;
   /* Contextual filter: OG membership: Group ID */
   $handler->display->display_options['arguments']['gid']['id'] = 'gid';


### PR DESCRIPTION
- Add a hidden view field to extract the group id
- Preprocess the view to override the read more link

Issue: http://platform.dandigbib.org/issues/1106.