### PR TITLE
Issue 510: Show single content type groups in full width

### DIFF
--- a/ding_news.views_default.inc
+++ b/ding_news.views_default.inc
@@ -439,6 +439,7 @@ function ding_news_views_default_views() {
   $handler->display->display_options['row_plugin'] = 'fields';
   $handler->display->display_options['row_options']['default_field_elements'] = FALSE;
   $handler->display->display_options['defaults']['row_options'] = FALSE;
+  $handler->display->display_options['defaults']['empty'] = FALSE;
   $handler->display->display_options['defaults']['relationships'] = FALSE;
   /* Relationship: OG membership: OG membership from Node */
   $handler->display->display_options['relationships']['og_membership_rel']['id'] = 'og_membership_rel';

--- a/ding_news.views_default.inc
+++ b/ding_news.views_default.inc
@@ -1406,14 +1406,6 @@ function ding_news_views_default_views() {
   $handler->display->display_options['row_options']['default_field_elements'] = FALSE;
   $handler->display->display_options['defaults']['row_options'] = FALSE;
   $handler->display->display_options['defaults']['empty'] = FALSE;
-  /* No results behavior: Global: Text area */
-  $handler->display->display_options['empty']['area']['id'] = 'area';
-  $handler->display->display_options['empty']['area']['table'] = 'views';
-  $handler->display->display_options['empty']['area']['field'] = 'area';
-  $handler->display->display_options['empty']['area']['label'] = 'Empty text';
-  $handler->display->display_options['empty']['area']['empty'] = TRUE;
-  $handler->display->display_options['empty']['area']['content'] = 'No news where found for this group.';
-  $handler->display->display_options['empty']['area']['format'] = 'ding_wysiwyg';
   $handler->display->display_options['defaults']['relationships'] = FALSE;
   /* Relationship: OG membership: OG membership from Node */
   $handler->display->display_options['relationships']['og_membership_rel']['id'] = 'og_membership_rel';
@@ -1856,7 +1848,6 @@ function ding_news_views_default_views() {
     t('news list by user'),
     t('Groups news list'),
     t('Group news'),
-    t('No news where found for this group.'),
     t('Groups panes'),
     t('News list (groups)'),
   );


### PR DESCRIPTION
This prevents the view from appearing if there is no news for the group and we can allow events to use the full width.

Issue: http://platform.dandigbib.org/issues/510

This is necessary for ding2/ddbasic#6 to work.
